### PR TITLE
Fix "Grab all links from a Website" example

### DIFF
--- a/examples/grab-all-links-from-a-website.md
+++ b/examples/grab-all-links-from-a-website.md
@@ -9,7 +9,7 @@ fun main() {
             htmlDocument {
                 a {
                     findAll {
-                        eachHrefAsAbsoluteLink
+                        eachHrefAsAbsoluteLink()
                     }
                 }
             }


### PR DESCRIPTION
The provided code wouldn't compile on my machine. I had to add round brackets in order to make it work.

Version:  implementation("it.skrape:skrapeit-core:1.0.0-alpha6")